### PR TITLE
Add porting guide page to doxygen

### DIFF
--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -3,11 +3,11 @@
 @brief Shadow library.
 
 > A device's shadow is a JSON document that is used to store and retrieve current state information for a device. The Device Shadow service maintains a shadow for each device you connect to AWS IoT. You can use the shadow to get and set the state of a device over MQTT or HTTP, regardless of whether the device is connected to the Internet. Each device's shadow is uniquely identified by the name of the corresponding thing.
-<span style="float:right;margin-right:4em"> &mdash; <i>Description of Device Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
+<span style="float:right;margin-right:4em"> &mdash; <i>Description of theDevice Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
 
-Device Shadow are the always-available device state in the AWS cloud. They are stored as JSON documents, and available via AWS even if the associated device goes offline. Common use cases for Device Shadow include backing up device state, or sending commands to devices.
+The Device Shadow is the always-available device state in the AWS cloud. The Device Shadow is stored as a JSON document, and available via AWS even if the associated device goes offline. Common use cases for the Device Shadow include backing up device state, or sending commands to devices.
 
-Embedded devices often use MQTT to interact with the Device Shadow.  This library provides a convenience API for handling MQTT topics reserved for Device Shadow.  This library is independent of the MQTT library.  Applications can use the macros and functions of this library to assemble and parse Device Shadow MQTT topics, then use any MQTT library to publish/subscribe to those topics.  Features of this library include:
+Embedded devices often use MQTT to interact with the Device Shadow.  This library provides a convenience API for handling MQTT topics reserved for the Device Shadow.  This library is independent of the MQTT library.  Applications can use the macros and functions of this library to assemble and parse the Device Shadow MQTT topics, then use any MQTT library to publish/subscribe to those topics.  Features of this library include:
 - It’s stateless.  It does not use any global/static memory.
 - It depends on standard C library (string.h and stdint.h) only.
 

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -3,11 +3,11 @@
 @brief Shadow library.
 
 > A device's shadow is a JSON document that is used to store and retrieve current state information for a device. The Device Shadow service maintains a shadow for each device you connect to AWS IoT. You can use the shadow to get and set the state of a device over MQTT or HTTP, regardless of whether the device is connected to the Internet. Each device's shadow is uniquely identified by the name of the corresponding thing.
-<span style="float:right;margin-right:4em"> &mdash; <i>Description of Device Shadows from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
+<span style="float:right;margin-right:4em"> &mdash; <i>Description of Device Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
 
-Device Shadows are the always-available device state in the AWS cloud. They are stored as JSON documents, and available via AWS even if the associated device goes offline. Common use cases for Device Shadows include backing up device state, or sending commands to devices.
+Device Shadow are the always-available device state in the AWS cloud. They are stored as JSON documents, and available via AWS even if the associated device goes offline. Common use cases for Device Shadow include backing up device state, or sending commands to devices.
 
-Embedded devices often use MQTT to interact with the Device Shadow.  This library provides a convenience API for handling MQTT topics reserved for Device Shadows.  This library is independent of the MQTT library.  Applications can use the macros and functions of this library to assemble and parse Device Shadow MQTT topics, then use any MQTT library to publish/subscribe to those topics.  Features of this library include:
+Embedded devices often use MQTT to interact with the Device Shadow.  This library provides a convenience API for handling MQTT topics reserved for Device Shadow.  This library is independent of the MQTT library.  Applications can use the macros and functions of this library to assemble and parse Device Shadow MQTT topics, then use any MQTT library to publish/subscribe to those topics.  Features of this library include:
 - It’s stateless.  It does not use any global/static memory.
 - It depends on standard C library (string.h and stdint.h) only.
 

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -3,7 +3,7 @@
 @brief Shadow library.
 
 > A device's shadow is a JSON document that is used to store and retrieve current state information for a device. The Device Shadow service maintains a shadow for each device you connect to AWS IoT. You can use the shadow to get and set the state of a device over MQTT or HTTP, regardless of whether the device is connected to the Internet. Each device's shadow is uniquely identified by the name of the corresponding thing.
-<span style="float:right;margin-right:4em"> &mdash; <i>Description of theDevice Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
+<span style="float:right;margin-right:4em"> &mdash; <i>Description of the Device Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
 
 The Device Shadow is the always-available device state in the AWS cloud. The Device Shadow is stored as a JSON document, and available via AWS even if the associated device goes offline. Common use cases for the Device Shadow include backing up device state, or sending commands to devices.
 

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -3,12 +3,12 @@
 @brief Shadow library.
 
 > A device's shadow is a JSON document that is used to store and retrieve current state information for a device. The Device Shadow service maintains a shadow for each device you connect to AWS IoT. You can use the shadow to get and set the state of a device over MQTT or HTTP, regardless of whether the device is connected to the Internet. Each device's shadow is uniquely identified by the name of the corresponding thing.
-<span style="float:right;margin-right:4em"> &mdash; <i>Description of the Device Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
+<span style="float:right;margin-right:4em"> &mdash; <i>Description of Device Shadow from AWS IoT documentation [https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)</i></span><br>
 
-The Device Shadow is the always-available device state in the AWS cloud. The Device Shadow is stored as a JSON document, and available via AWS even if the associated device goes offline. Common use cases for the Device Shadow include backing up device state, or sending commands to devices.
+Device Shadow is the always-available device state in the AWS cloud. A device's shadow is stored as a JSON document, and available via AWS even if the associated device goes offline. Common use cases for Device Shadow include backing up device state, or sending commands to devices.
 
-Embedded devices often use MQTT to interact with the Device Shadow.  This library provides a convenience API for handling MQTT topics reserved for the Device Shadow.  This library is independent of the MQTT library.  Applications can use the macros and functions of this library to assemble and parse the Device Shadow MQTT topics, then use any MQTT library to publish/subscribe to those topics.  Features of this library include:
-- It’s stateless.  It does not use any global/static memory.
+Embedded devices often use MQTT to interact with Device Shadow. This library provides a convenience API for handling MQTT topics reserved for Device Shadow.  This library is independent of the MQTT library.  Applications can use the macros and functions of this library to assemble and parse the Device Shadow MQTT topics, then use any MQTT library to publish/subscribe to those topics.  Features of this library include:
+- It is stateless.  It does not use any global/static memory.
 - It depends on standard C library (string.h and stdint.h) only.
 
 @section shadow_memory_requirements Memory Requirements

--- a/docs/doxygen/porting.txt
+++ b/docs/doxygen/porting.txt
@@ -1,0 +1,22 @@
+/**
+@page shadow_porting Porting Guide
+@brief Guide for porting Shadow to a new platform.
+
+A port to a new system must provide the following components:
+1. [Configuration Macros](@ref porting_config)
+
+@section porting_config Configuration Macros
+@brief Settings that must be set as macros in the config header `shadow_config.h`, or passed in as compiler options
+
+@see [Configurations](@ref shadow_config)
+
+@note Regardless of whether the following macros are defined in `shadow_config.h` or passed as compiler options,
+the `shadow_config.h` file must be included to build the Shadow library.
+
+The following logging macros are used throughout the library:
+ - @ref LogError
+ - @ref LogWarn
+ - @ref LogInfo
+ - @ref LogDebug
+
+ */

--- a/docs/doxygen/porting.txt
+++ b/docs/doxygen/porting.txt
@@ -2,21 +2,18 @@
 @page shadow_porting Porting Guide
 @brief Guide for porting Shadow to a new platform.
 
-A port to a new system must provide the following components:
-1. [Configuration Macros](@ref porting_config)
-
 @section porting_config Configuration Macros
-@brief Settings that must be set as macros in the config header `shadow_config.h`, or passed in as compiler options
+@brief Settings that can be set as macros in the config header `shadow_config.h`, or passed in as compiler options.
 
-@see [Configurations](@ref shadow_config)
-
-@note Regardless of whether the following macros are defined in `shadow_config.h` or passed as compiler options,
-the `shadow_config.h` file must be included to build the Shadow library.
-
-The following logging macros are used throughout the library:
+The following optional logging macros are used throughout the library:
  - @ref LogError
  - @ref LogWarn
  - @ref LogInfo
  - @ref LogDebug
 
+@see [Configurations](@ref shadow_config) for more information.
+
+@note Regardless of whether the following macros are defined in `shadow_config.h` or passed as compiler options,
+the `shadow_config.h` file must be included to build the Shadow library. To disable this requirement
+and build the library with default configuration values, provide `SHADOW_DO_NOT_USE_CUSTOM_CONFIG` as a compile time preprocessor macro.
  */


### PR DESCRIPTION
*Description of changes:*
Add porting guide page to doxygen.
- create docs/doxygen/porting.txt for porting guide page.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
