### PR TITLE
Update README.md to not reference "development" branch in CSDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
         with:
           ref: master
           repository: aws/aws-iot-device-sdk-embedded-C
-      - run: rm -r libraries/aws/shadow
+      - run: rm -r libraries/aws/device-shadow-for-aws-iot-embedded-sdk
       - name: Clone This Repo
         uses: actions/checkout@v2
         with:
-          path: libraries/aws/shadow
+          path: libraries/aws/device-shadow-for-aws-iot-embedded-sdk
       - name: Install spell
         run: |
           sudo apt-get install spell
@@ -82,7 +82,7 @@ jobs:
       - name: Check spelling
         run: |
           PATH=$PATH:$PWD/tools/spell
-          for lexfile in `find libraries/aws/shadow -name lexicon.txt`
+          for lexfile in `find libraries/aws/device-shadow-for-aws-iot-embedded-sdk -name lexicon.txt`
           do dir=${lexfile%/lexicon.txt}
             echo $dir
             find-unknown-comment-words --directory $dir

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a Device Shadow client library for embedded platforms t
 
 ### Device Shadow Config File
 The Device Shadow library exposes build configuration macros that are required for building the library.
-A list of all the configurations and their default values are defined in [shadow_config_defaults.h](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk/blob/master/source/include/shadow_config_defaults.h). 
+A list of all the configurations and their default values are defined in [shadow_config_defaults.h](source/include/shadow_config_defaults.h). 
 To provide custom values for the configuration macros, a custom config file named `shadow_config.h` can be provided by the application to the library.
 
 By default, a `shadow_config.h` custom config is required to build the library. To disable this requirement
@@ -12,11 +12,11 @@ and build the library with default configuration values, provide `SHADOW_DO_NOT_
 
 ## Building the Library
 
-The [shadowFilePaths.cmake](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk/blob/master/shadowFilePaths.cmake) file contains the information of all source files and the header include path required to build the Shadow library.
+The [shadowFilePaths.cmake](shadowFilePaths.cmake) file contains the information of all source files and the header include path required to build the Shadow library.
 
 As mentioned in the previous section, either a custom config file (i.e. `shadow_config.h`) OR the `SHADOW_DO_NOT_USE_CUSTOM_CONFIG` macro needs to be provided to build the Shadow library.
 
-For a CMake example of building the Shadow library with the `shadowFilePaths.cmake` file, refer to the `coverity_analysis` library target in [test/CMakeLists.txt](https://github.com/aws/device-shadow-for-aws-iot-embedded-sdk/blob/master/test/CMakeLists.txt) file.
+For a CMake example of building the Shadow library with the `shadowFilePaths.cmake` file, refer to the `coverity_analysis` library target in [test/CMakeLists.txt](test/CMakeLists.txt) file.
 
 ## Building Unit Tests
 
@@ -24,7 +24,7 @@ For a CMake example of building the Shadow library with the `shadowFilePaths.cma
 
 - For building the library, **CMake 3.13.0** or later and a **C90 compiler**.
 - For running unit tests, **Ruby 2.0.0** or later is additionally required for the CMock test framework (that we use).
-- For running the coverage target, **gcov** is additionally required.
+- For running the coverage target, **gcov** and **lcov** are additionally required.
 
 ### Steps to build unit tests
 
@@ -32,7 +32,7 @@ For a CMake example of building the Shadow library with the `shadowFilePaths.cma
 
 1. Create a build directory: `mkdir build && cd build`
 
-1. Run *cmake* while inside the build directory: `cmake ../test -DBUILD_CLONE_SUBMODULES=ON`
+1. Run the *cmake* command: `cmake ../test -DBUILD_CLONE_SUBMODULES=ON`
 
 1. Run this command to build the library and unit tests: `make all`
 
@@ -42,7 +42,7 @@ For a CMake example of building the Shadow library with the `shadowFilePaths.cma
 
 ## Reference examples
 
-The AWS IoT Embedded C-SDK repository contains demos of using the Device Shadow library [here](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/development/demos/shadow) on a POSIX platform. These can be used as reference examples for the library API.
+The AWS IoT Embedded C-SDK repository contains demos of using the Device Shadow library [here](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/demos/shadow) on a POSIX platform. These can be used as reference examples for the library API.
 
 ## Generating documentation
 


### PR DESCRIPTION
- Update to use relative paths in this repo.
- Update to not point to the development branch in other links.
- Update for some wording.
- Fix Github actions for submodule in CSDK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
