### PR TITLE
Coverage fix

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -58,6 +58,7 @@ shadowtopicstringtypeupdateaccepted
 shadowtopicstringtypeupdatedelta
 shadowtopicstringtypeupdatedocuments
 shadowtopicstringtypeupdaterejected
+shadowtopicstringtypemaxnum
 sizeof
 stringlength
 strlen

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -302,6 +302,7 @@ static ShadowStatus_t extractShadowMessageType( const char * pString,
     {
         LogDebug( ( "Not related to Shadow, failed to match shadow message type in pString %s", pString ) );
     }
+
     return returnStatus;
 }
 

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -298,6 +298,10 @@ static ShadowStatus_t extractShadowMessageType( const char * pString,
         }
     }
 
+    if( returnStatus != SHADOW_SUCCESS )
+    {
+        LogDebug( ( "Not related to Shadow, failed to match shadow message type in pString %s", pString ) );
+    }
     return returnStatus;
 }
 
@@ -350,12 +354,9 @@ static const char * getShadowOperationString( ShadowTopicStringType_t topicType 
             break;
 
         case ShadowTopicStringTypeUpdateDelta:
-            shadowOperationString = SHADOW_OP_UPDATE_DELTA;
-            break;
-
+        /* topicType >= ShadowTopicStringTypeMaxNum check is covered at entry of Shadow_GetTopicString.*/
         default:
-            LogError( ( "Unexpected  topicType: %u", topicType ) );
-            shadowOperationString = NULL;
+            shadowOperationString = SHADOW_OP_UPDATE_DELTA;
             break;
     }
 
@@ -411,11 +412,9 @@ static uint16_t getShadowOperationLength( ShadowTopicStringType_t topicType )
             break;
 
         case ShadowTopicStringTypeUpdateDelta:
-            shadowOperationLength = SHADOW_OP_UPDATE_DELTA_LENGTH;
-            break;
-
+        /* topicType >= ShadowTopicStringTypeMaxNum check is covered at entry of Shadow_GetTopicString.*/
         default:
-            LogError( ( "Unexpected  topicType: %u", topicType ) );
+            shadowOperationLength = SHADOW_OP_UPDATE_DELTA_LENGTH;
             break;
     }
 
@@ -517,11 +516,6 @@ ShadowStatus_t Shadow_MatchTopic( const char * pTopic,
         shadowStatus = extractShadowMessageType( &( pTopic[ consumedTopicLength ] ),
                                                  topicLength - consumedTopicLength,
                                                  pMessageType );
-
-        if( shadowStatus != SHADOW_SUCCESS )
-        {
-            LogDebug( ( "Not related to Shadow, failed to match shadow message type in pTopic %s", pTopic ) );
-        }
     }
 
     return shadowStatus;
@@ -538,6 +532,7 @@ ShadowStatus_t Shadow_GetTopicString( ShadowTopicStringType_t topicType,
     uint16_t offset = 0U, generatedTopicStringLength = 0U, operationStringLength = 0U;
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
     const char * pOperationString = NULL;
+    const char shadowPrefix[ SHADOW_PREFIX_LENGTH ] = SHADOW_PREFIX;
 
     if( ( pTopicBuffer == NULL ) ||
         ( pThingName == NULL ) ||
@@ -568,7 +563,7 @@ ShadowStatus_t Shadow_GetTopicString( ShadowTopicStringType_t topicType,
         {
             /* Copy the Shadow topic prefix into the topic buffer. */
             ( void ) memcpy( ( void * ) pTopicBuffer,
-                             ( const void * ) SHADOW_PREFIX,
+                             ( const void * ) shadowPrefix,
                              ( size_t ) SHADOW_PREFIX_LENGTH );
             offset = ( uint16_t ) ( offset + SHADOW_PREFIX_LENGTH );
 

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -355,7 +355,7 @@ static const char * getShadowOperationString( ShadowTopicStringType_t topicType 
             break;
 
         case ShadowTopicStringTypeUpdateDelta:
-        /* topicType >= ShadowTopicStringTypeMaxNum check is covered at entry of Shadow_GetTopicString.*/
+        /* topicType >= ShadowTopicStringTypeMaxNum check is covered at entry of Shadow_GetTopicString. */
         default:
             shadowOperationString = SHADOW_OP_UPDATE_DELTA;
             break;
@@ -413,7 +413,7 @@ static uint16_t getShadowOperationLength( ShadowTopicStringType_t topicType )
             break;
 
         case ShadowTopicStringTypeUpdateDelta:
-        /* topicType >= ShadowTopicStringTypeMaxNum check is covered at entry of Shadow_GetTopicString.*/
+        /* topicType >= ShadowTopicStringTypeMaxNum check is covered at entry of Shadow_GetTopicString. */
         default:
             shadowOperationLength = SHADOW_OP_UPDATE_DELTA_LENGTH;
             break;

--- a/test/unit-test/shadow_utest.c
+++ b/test/unit-test/shadow_utest.c
@@ -505,6 +505,24 @@ void test_Shadow_MatchTopic_Happy_Path( void )
     TEST_ASSERT_EQUAL_INT( TEST_THING_NAME_LENGTH, thingNameLength );
     TEST_ASSERT_EQUAL_INT( ShadowMessageTypeUpdateAccepted, messageType );
     TEST_ASSERT_EQUAL_STRING_LEN( TEST_THING_NAME, pThingName, TEST_THING_NAME_LENGTH );
+
+    shadowStatus = Shadow_MatchTopic( &( topicBuffer[ 0 ] ),
+                                      bufferSize,
+                                      &messageType,
+                                      NULL,
+                                      &thingNameLength );
+    TEST_ASSERT_EQUAL_INT( SHADOW_SUCCESS, shadowStatus );
+    TEST_ASSERT_EQUAL_INT( TEST_THING_NAME_LENGTH, thingNameLength );
+    TEST_ASSERT_EQUAL_INT( ShadowMessageTypeUpdateAccepted, messageType );
+
+    shadowStatus = Shadow_MatchTopic( &( topicBuffer[ 0 ] ),
+                                      bufferSize,
+                                      &messageType,
+                                      &pThingName,
+                                      NULL );
+    TEST_ASSERT_EQUAL_INT( SHADOW_SUCCESS, shadowStatus );
+    TEST_ASSERT_EQUAL_INT( ShadowMessageTypeUpdateAccepted, messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( TEST_THING_NAME, pThingName, TEST_THING_NAME_LENGTH );
 }
 
 /*-----------------------------------------------------------*/
@@ -544,20 +562,6 @@ void test_Shadow_MatchTopic_Invalid_Parameters( void )
                                       &pThingName,
                                       &thingNameLength );
 
-    TEST_ASSERT_EQUAL_INT( SHADOW_BAD_PARAMETER, shadowStatus );
-
-    shadowStatus = Shadow_MatchTopic( &( topicBuffer[ 0 ] ),
-                                      bufferSize,
-                                      &messageType,
-                                      NULL,
-                                      &thingNameLength );
-    TEST_ASSERT_EQUAL_INT( SHADOW_BAD_PARAMETER, shadowStatus );
-
-    shadowStatus = Shadow_MatchTopic( &( topicBuffer[ 0 ] ),
-                                      bufferSize,
-                                      &messageType,
-                                      &pThingName,
-                                      NULL );
     TEST_ASSERT_EQUAL_INT( SHADOW_BAD_PARAMETER, shadowStatus );
 
     shadowStatus = Shadow_MatchTopic( TEST_SHADOW_TOPIC_STRING_INVALID_PREFIX,

--- a/test/unit-test/shadow_utest.c
+++ b/test/unit-test/shadow_utest.c
@@ -389,6 +389,7 @@ void test_Shadow_GetTopicString_Happy_Path( void )
     TEST_ASSERT_EQUAL_STRING_LEN( TEST_SHADOW_TOPIC_STRING_GET_ACCEPTED,
                                   topicBufferGetAccepted,
                                   bufferSizeGetAccepted );
+
     for( index = 0; index < ShadowTopicStringTypeMaxNum; index++ )
     {
         /* Call Shadow_GetTopicString() with valid parameters with all types of topic string

--- a/tools/misra.config
+++ b/tools/misra.config
@@ -1,0 +1,46 @@
+// MISRA C-2012 Rules
+
+{
+    version : "2.0",
+    standard : "c2012",
+    title: "Coverity MISRA Configuration",
+    deviations : [
+        // Disable the following rules.
+        {
+            deviation: "Directive 4.5",
+            reason: "Allow names that MISRA considers ambiguous (such as LogInfo and LogError)."
+        },
+        {
+            deviation: "Directive 4.8",
+            reason: "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
+        },
+        {
+            deviation: "Directive 4.9",
+            reason: "Allow inclusion of function like macros. Logging is done using function like macros."
+        },
+        {
+            deviation: "Rule 2.4",
+            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+        },
+        {
+            deviation: "Rule 2.5",
+            reason: "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
+        },
+        {
+            deviation: "Rule 3.1",
+            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+        },
+        {
+            deviation: "Rule 11.5",
+            reason: "Allow casts from void *. Contexts are passed as void * and must be cast to the correct data type before use."
+        },
+        {
+            deviation: "Rule 21.1",
+            reason: "Allow use of all macro names. For compatibility, some macros introduced in C99 are defined for use with C90 compilers."
+        },
+        {
+            deviation: "Rule 21.2",
+            reason: "Allow use of all macro and identifier names. For compatibility, some macros introduced in C99 are defined for use with C90 compilers."
+        }
+    ]
+}


### PR DESCRIPTION
1.  Allow users to use NULL for pThingName, pThingNameLength when invoke Shadow_MatchTopic
    If they are not interested in  pThingName, pThingNameLength.
    (Align Jobs Match topic style)

2. Made relative changes to make complexity lesser after adding #1.





