### PR TITLE
Add MISRA.md documentation file

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -15,8 +15,6 @@ Deviations from the MISRA standard are listed below:
 | Rule 2.5 | Advisory | Allow unused macros. Library headers may define macros intended for the application's use, but are not used by a specific file. |
 | Rule 3.1 | Required | Allow nested comments. C++ style `//` comments are used in example code within Doxygen documentation blocks. |
 | Rule 11.5 | Advisory | Allow casts from `void *`. Fields may be passed as `void *`, requiring a cast to the correct data type before use. |
-| Rule 21.1 | Required | Allow use of all macro names. No such violations exist in this library, but other libraries may define macros introduced in C99 for use with C90 compilers. |
-| Rule 21.2 | Required | Allow use of all macro and identifier names. No such violations exist in this library, but other libraries may define macros introduced in C99 for use with C90 compilers. |
 
 ### Flagged by Coverity
 | Deviation | Category | Justification |

--- a/MISRA.md
+++ b/MISRA.md
@@ -1,0 +1,27 @@
+# MISRA Compliance
+
+The Device Shadow library files conform to the [MISRA C:2012](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx)
+guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
+Deviations from the MISRA standard are listed below:
+
+### Ignored by [Coverity Configuration](https://github.com/aws/aws-iot-device-sdk-embedded-C/blob/master/tools/coverity/misra.config)
+| Deviation | Category | Justification |
+| :-: | :-: | :-: |
+| Directive 4.5 | Advisory | Allow names that MISRA considers ambiguous (such as LogInfo and LogError) |
+| Directive 4.8 | Advisory | Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file. |
+| Directive 4.9 | Advisory | Allow inclusion of function like macros. The `assert` macro is used throughout the library for parameter validation, and logging is done using function like macros. |
+| Rule 2.3 | Advisory | Allow unused types. Library headers may define types intended for the application's use, but not used within the library files. |
+| Rule 2.4 | Advisory | Allow unused tags. Some compilers warn if types are not tagged. |
+| Rule 2.5 | Advisory | Allow unused macros. Library headers may define macros intended for the application's use, but are not used by a specific file. |
+| Rule 3.1 | Required | Allow nested comments. C++ style `//` comments are used in example code within Doxygen documentation blocks. |
+| Rule 11.5 | Advisory | Allow casts from `void *`. Fields may be passed as `void *`, requiring a cast to the correct data type before use. |
+| Rule 21.1 | Required | Allow use of all macro names. No such violations exist in this library, but other libraries may define macros introduced in C99 for use with C90 compilers. |
+| Rule 21.2 | Required | Allow use of all macro and identifier names. No such violations exist in this library, but other libraries may define macros introduced in C99 for use with C90 compilers. |
+
+### Flagged by Coverity
+| Deviation | Category | Justification |
+| :-: | :-: | :-: |
+| Rule 8.7 | Advisory | API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application. |
+
+### Suppressed with Coverity Comments
+*None.*

--- a/MISRA.md
+++ b/MISRA.md
@@ -4,7 +4,7 @@ The Device Shadow library files conform to the [MISRA C:2012](https://www.misra.
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
 Deviations from the MISRA standard are listed below:
 
-### Ignored by [Coverity Configuration](https://github.com/aws/aws-iot-device-sdk-embedded-C/blob/master/tools/coverity/misra.config)
+### Ignored by [Coverity Configuration](tools/misra.config)
 | Deviation | Category | Justification |
 | :-: | :-: | :-: |
 | Directive 4.5 | Advisory | Allow names that MISRA considers ambiguous (such as LogInfo and LogError) |


### PR DESCRIPTION
*Description*:
Adds a document for MISRA compliance, similar to [MQTT's](https://github.com/FreeRTOS/coreMQTT/blob/master/MISRA.md). Notable changes in this document include:
 * Moved Rule 2.3 from the "Flagged" to "Ignored" section due to https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1235
 * Changed justification of 11.5 due to this library not dealing with publish payloads.
 * Changed justification of 21.1 and 21.2 since no such violations will in this library after #18 .
