### PR TITLE
Add shadow_ prefix to porting guide to help with future tags.

### DIFF
--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -61,16 +61,16 @@ Some configuration settings are C pre-processor constants, and some are function
 @section SHADOW_DO_NOT_USE_CUSTOM_CONFIG
 @copydoc SHADOW_DO_NOT_USE_CUSTOM_CONFIG
 
-@section LogError
+@section shadow_logerror LogError
 @copydoc LogError
 
-@section LogWarn
+@section shadow_logwarn LogWarn
 @copydoc LogWarn
 
-@section LogInfo
+@section shadow_loginfo LogInfo
 @copydoc LogInfo
 
-@section LogDebug
+@section shadow_logdebug LogDebug
 @copydoc LogDebug
 */
 

--- a/docs/doxygen/porting.txt
+++ b/docs/doxygen/porting.txt
@@ -2,7 +2,7 @@
 @page shadow_porting Porting Guide
 @brief Guide for porting Shadow to a new platform.
 
-@section porting_config Configuration Macros
+@section shadow_porting_config Configuration Macros
 @brief Settings that can be set as macros in the config header `shadow_config.h`, or passed in as compiler options.
 
 The following optional logging macros are used throughout the library:


### PR DESCRIPTION
Other libraries will have a porting guide and they will need to distinguish their section anchors from others. 
All libraries generate a TAG for the hub repo to use. If there are multiple definitions across tag files for the hub a warning will be emitted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
