### PR TITLE
Update code sizes

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -28,13 +28,13 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td>shadow.c</td>
-        <td>0.84K</td>
-        <td>0.68K</td>
+        <td>1.78K</td>
+        <td>0.95K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>0.84K</td>
-        <td>0.68K</td>
+        <td>1.78K</td>
+        <td>0.95K</td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -19,7 +19,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="3"><b>Code Size of Shadow Library(example generated with GCC for ARM Cortex-M)</b></td>
+        <td colspan="3"><b>Code Size of Shadow Library (example generated with GCC for ARM Cortex-M)</b></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -19,7 +19,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code Size of Device Shadow Library (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads))</b></center></td>
+        <td colspan="4"><center><b>Code Size of Device Shadow Library (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -23,16 +23,19 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>With -O1 Optimisation</b></td>
-        <td><b>With -Os Optimisation</b></td>
+        <td><b>No Optimisation (asserts enabled)</b></td>
+        <td><b>With -O1 Optimisation (asserts disabled)</b></td>
+        <td><b>With -Os Optimisation (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>shadow.c</td>
+        <td>2.3K</td>
         <td>1.8K</td>
         <td>1.0K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
+        <td>2.3K</td>
         <td>1.8K</td>
         <td>1.0K</td>
     </tr>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -28,13 +28,13 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td>shadow.c</td>
-        <td>1.78K</td>
-        <td>0.95K</td>
+        <td>1.8K</td>
+        <td>1.0K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>1.78K</td>
-        <td>0.95K</td>
+        <td>1.8K</td>
+        <td>1.0K</td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -19,7 +19,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="3"><b>Code Size of Shadow Library (example generated with GCC for ARM Cortex-M)</b></td>
+        <td colspan="4"><center><b>Code Size of Device Shadow Library (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -23,18 +23,12 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>No Optimisation (asserts enabled)</b></td>
-        <td><b>With -O1 Optimisation (asserts disabled)</b></td>
-        <td><b>With -Os Optimisation (asserts disabled)</b></td>
+        <td><b>No Optimization (asserts enabled)</b></td>
+        <td><b>With -O1 Optimization (asserts disabled)</b></td>
+        <td><b>With -Os Optimization (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>shadow.c</td>
-        <td>2.3K</td>
-        <td>1.8K</td>
-        <td>1.0K</td>
-    </tr>
-    <tr>
-        <td><b>Total estimates</b></td>
         <td>2.3K</td>
         <td>1.8K</td>
         <td>1.0K</td>


### PR DESCRIPTION
I calculated code sizes after adding version numbers in PR #21 

**Note: I am always rounding up.**
O0:
 size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   2272       0       0    2272     8e0 shadow.c.obj (ex libcoverity_analysis.a)
   2272       0       0    2272     8e0 (TOTALS)
```
O1:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   1773       0       0    1773     6ed shadow.c.obj (ex libcoverity_analysis.a)
   1773       0       0    1773     6ed (TOTALS)
```
Os:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
    944       0       0     944     3b0 shadow.c.obj (ex libcoverity_analysis.a)
    944       0       0     944     3b0 (TOTALS)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
