### PR TITLE
Update submodule configuration for hub repo cloning efficiency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
+      - name: Checkout CMock submodule
+        run: git submodule update --checkout --init --recursive test/unit-test/CMock
       - name: Build
         run: |
           sudo apt-get install -y lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,13 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
-      - name: Checkout CMock submodule
-        run: git submodule update --checkout --init --recursive test/unit-test/CMock
       - name: Build
         run: |
           sudo apt-get install -y lcov
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
           make -C build/ all
       - name: Test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "test/unit-test/CMock"]
 	path = test/unit-test/CMock
 	url = https://github.com/ThrowTheSwitch/CMock
+	update = none
 [submodule "test/cbmc/aws-templates-for-cbmc-proofs"]
 	path = test/cbmc/aws-templates-for-cbmc-proofs
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
+	update = none
 [submodule "test/cbmc/litani"]
 	path = test/cbmc/litani
 	url = https://github.com/awslabs/aws-build-accumulator
+	update = none

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git submodule update --checkout --init --recursive --test/unit-test/CMock
 
 1. Go to the root directory of this repository. (Make sure that the **CMock** submodule is cloned as described [above](#checkout-cmock-submodule).)
 
-1. Run the *cmake* command: `cmake -S test -B build -DBUILD_CLONE_SUBMODULES=ON `
+1. Run the *cmake* command: `cmake -S test -B build`
 
 1. Run this command to build the library and unit tests: `make -C build all`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ For a CMake example of building the AWS IoT Device Shadow library with the `shad
 
 ## Building Unit Tests
 
+### Checkout CMock Submodule
+By default, the submodules in this repository are configured with `update=none` in [.gitmodules](.gitmodules) to avoid increasing clone time and disk space usage of other repositories (like [amazon-freertos](https://github.com/aws/amazon-freertos) that submodule this repository.
+
+To build unit tests, the submodule dependency of CMock is required. Use the following command to clone the submodule:
+```
+git submodule update --checkout --init --recursive --test/unit-test/CMock
+```
+
 ### Platform Prerequisites
 
 - For building the library, **CMake 3.13.0** or later and a **C90 compiler**.
@@ -30,7 +38,7 @@ For a CMake example of building the AWS IoT Device Shadow library with the `shad
 
 ### Steps to build unit tests
 
-1. Go to the root directory of this repository.
+1. Go to the root directory of this repository. (Make sure that the **CMock** submodule is cloned as described [above](#checkout-cmock-submodule).)
 
 1. Run the *cmake* command: `cmake -S test -B build -DBUILD_CLONE_SUBMODULES=ON `
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ set(MODULE_ROOT_DIR ${__MODULE_ROOT_DIR} CACHE INTERNAL "Shadow repository root.
 # Configure options to always show in CMake GUI.
 option( BUILD_CLONE_SUBMODULES
         "Set this to ON to automatically clone any required Git submodules. When OFF, submodules must be manually cloned."
-        ON )
+        OFF )
 
 # Set output directories.
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )

--- a/test/unit-test/cmock_build.cmake
+++ b/test/unit-test/cmock_build.cmake
@@ -3,7 +3,7 @@ macro( clone_cmock )
         find_package( Git REQUIRED )
         message( "Cloning submodule CMock." )
         execute_process( COMMAND rm -rf ${CMOCK_DIR}
-                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${CMOCK_DIR}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --checkout --init --recursive ${CMOCK_DIR}
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                         RESULT_VARIABLE CMOCK_CLONE_RESULT )
 


### PR DESCRIPTION
Reduce the cloning time of hub repositories (`aws/aws-iot-device-sdk-embedded-C`, `aws/amazon-freertos`) that consume this repository by updating submodules to not be auto-cloned for `git submodule update --init --recursive` command in the hub repositories
﻿