### PR TITLE
Fix build warning from visual studio due to terminator character

### DIFF
--- a/source/shadow.c
+++ b/source/shadow.c
@@ -543,7 +543,7 @@ ShadowStatus_t Shadow_GetTopicString( ShadowTopicStringType_t topicType,
     uint16_t offset = 0U, generatedTopicStringLength = 0U, operationStringLength = 0U;
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
     const char * pOperationString = NULL;
-    const char * shadowPrefix = SHADOW_PREFIX;
+    const char * pShadowPrefix = SHADOW_PREFIX;
 
     if( ( pTopicBuffer == NULL ) ||
         ( pThingName == NULL ) ||
@@ -574,7 +574,7 @@ ShadowStatus_t Shadow_GetTopicString( ShadowTopicStringType_t topicType,
         {
             /* Copy the Shadow topic prefix into the topic buffer. */
             ( void ) memcpy( ( void * ) pTopicBuffer,
-                             ( const void * ) shadowPrefix,
+                             ( const void * ) pShadowPrefix,
                              ( size_t ) SHADOW_PREFIX_LENGTH );
             offset = ( uint16_t ) ( offset + SHADOW_PREFIX_LENGTH );
 

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -543,7 +543,7 @@ ShadowStatus_t Shadow_GetTopicString( ShadowTopicStringType_t topicType,
     uint16_t offset = 0U, generatedTopicStringLength = 0U, operationStringLength = 0U;
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
     const char * pOperationString = NULL;
-    const char shadowPrefix[ SHADOW_PREFIX_LENGTH + 1 ] = SHADOW_PREFIX;
+    const char * shadowPrefix = SHADOW_PREFIX;
 
     if( ( pTopicBuffer == NULL ) ||
         ( pThingName == NULL ) ||

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -543,7 +543,7 @@ ShadowStatus_t Shadow_GetTopicString( ShadowTopicStringType_t topicType,
     uint16_t offset = 0U, generatedTopicStringLength = 0U, operationStringLength = 0U;
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
     const char * pOperationString = NULL;
-    const char shadowPrefix[ SHADOW_PREFIX_LENGTH ] = SHADOW_PREFIX;
+    const char shadowPrefix[ SHADOW_PREFIX_LENGTH + 1 ] = SHADOW_PREFIX;
 
     if( ( pTopicBuffer == NULL ) ||
         ( pThingName == NULL ) ||


### PR DESCRIPTION
*Description of changes:*
Visual studio will build warning due to the length not enough for terminator character


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
