### PR TITLE
Update README example references to contain links to all hub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ git submodule update --checkout --init --recursive --test/unit-test/CMock
 
 ## Reference examples
 
-The AWS IoT Embedded C-SDK repository contains demos of using the AWS IoT Device Shadow library [here](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/demos/shadow) on a POSIX platform. These can be used as reference examples for the library API.
+Please refer to the demos of the AWS IoT Device Shadow library in the following locations for reference examples on POSIX and FreeRTOS platforms:
+
+| Platform | Location | Transport Interface Implementation |
+| :-: | :-: | :-: |
+| POSIX | [AWS IoT Device SDK for Embedded C](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/demos/shadow/shadow_demo_main) | POSIX sockets for TCP/IP and OpenSSL for TLS stack
+| FreeRTOS | [FreeRTOS/FreeRTOS](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator) | FreeRTOS+TCP for TCP/IP and mbedTLS for TLS stack |
+| FreeRTOS | [FreeRTOS AWS Reference Integrations](https://github.com/aws/amazon-freertos/tree/master/demos/device_shadow_for_aws) | Based on Secure Sockets Abstraction |
 
 ## Generating documentation
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git submodule update --checkout --init --recursive --test/unit-test/CMock
 
 Please refer to the demos of the AWS IoT Device Shadow library in the following locations for reference examples on POSIX and FreeRTOS platforms:
 
-| Platform | Location | Transport Interface Implementation |
+| Platform | Location | Transport Interface Implementation <br> (for [coreMQTT](https://github.com/FreeRTOS/coreMQTT) stack) </br> |
 | :-: | :-: | :-: |
 | POSIX | [AWS IoT Device SDK for Embedded C](https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/demos/shadow/shadow_demo_main) | POSIX sockets for TCP/IP and OpenSSL for TLS stack
 | FreeRTOS | [FreeRTOS/FreeRTOS](https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS-Plus/Demo/AWS/Device_Shadow_Windows_Simulator) | FreeRTOS+TCP for TCP/IP and mbedTLS for TLS stack |


### PR DESCRIPTION
Update **Reference Examples** section of README to contain links to Device Shadow demos in FreeRTOS repositories.