### PR TITLE
Make run script return zero on proof failure

### DIFF
--- a/test/cbmc/proofs/run-cbmc-proofs.py
+++ b/test/cbmc/proofs/run-cbmc-proofs.py
@@ -160,7 +160,7 @@ def get_proof_dirs(proof_root, proof_list, proof_marker):
 
 
 def run_build(litani, jobs):
-    cmd = [str(litani), "run-build"]
+    cmd = [str(litani), "run-build", "--exit-zero-on-fail"]
     if jobs:
         cmd.extend(["-j", str(jobs)])
 


### PR DESCRIPTION
Prior to this commit, litani would return a non-zero code when any proof
job failed, and the run script would throw an exception when this
happened.

This commit adds the --exit-zero-on-fail flag to the litani run-build
invocation, so that litani returns zero even if there are proof failures
(but will continue to return a non-zero exit code if there was a crash
or some other error).

This is so that CI can distinguish between proof failures (which can be
detected in the litani JSON output), and litani crashes due to bugs in
litani, inconsistent builds, or other errors.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
