### PR TITLE
Address inconsistency in types.

### DIFF
--- a/source/include/shadow.h
+++ b/source/include/shadow.h
@@ -789,9 +789,9 @@ ShadowStatus_t Shadow_MatchTopicString( const char * pTopic,
                                         uint16_t topicLength,
                                         ShadowMessageType_t * pMessageType,
                                         const char ** pThingName,
-                                        uint16_t * pThingNameLength,
+                                        uint8_t * pThingNameLength,
                                         const char ** pShadowName,
-                                        uint16_t * pShadowNameLength );
+                                        uint8_t * pShadowNameLength );
 /* @[declare_shadow_matchtopicstring] */
 
 /*------------- Shadow library backwardly-compatible constants -------------*/
@@ -1048,8 +1048,11 @@ ShadowStatus_t Shadow_MatchTopicString( const char * pTopic,
  * See @ref Shadow_MatchTopicString for documentation of common behavior.
  */
 /* @[declare_shadow_matchtopic] */
-#define Shadow_MatchTopic( pTopic, topicLength, pMessageType, pThingName, pThingNameLength ) \
-    Shadow_MatchTopicString( pTopic, topicLength, pMessageType, pThingName, pThingNameLength, NULL, 0 )
+ShadowStatus_t Shadow_MatchTopic( const char * pTopic,
+                                  uint16_t topicLength,
+                                  ShadowMessageType_t * pMessageType,
+                                  const char ** pThingName,
+                                  uint16_t * pThingNameLength );
 /* @[declare_shadow_matchtopic] */
 
 #endif /* ifndef SHADOW_H_ */

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -154,13 +154,13 @@ static ShadowStatus_t validateMatchTopicParameters( const char * pTopic,
  * @return Return SHADOW_SUCCESS if the parameters are valid;
  *         return SHADOW_BAD_PARAMETER if not.
  */
-ShadowStatus_t validateAssembleTopicParameters( ShadowTopicStringType_t topicType,
-                                                const char * pThingName,
-                                                uint8_t thingNameLength,
-                                                const char * pShadowName,
-                                                uint8_t shadowNameLength,
-                                                char * pTopicBuffer,
-                                                uint16_t * pOutLength );
+static ShadowStatus_t validateAssembleTopicParameters( ShadowTopicStringType_t topicType,
+                                                       const char * pThingName,
+                                                       uint8_t thingNameLength,
+                                                       const char * pShadowName,
+                                                       uint8_t shadowNameLength,
+                                                       const char * pTopicBuffer,
+                                                       const uint16_t * pOutLength );
 
 /**
  * @brief Determine if the string contains the substring.
@@ -191,8 +191,8 @@ static ShadowStatus_t containsSubString( const char * pString,
  */
 static ShadowStatus_t validateName( const char * pString,
                                     uint16_t stringLength,
-                                    uint16_t maxAllowedLength,
-                                    uint16_t * pNameLength );
+                                    uint8_t maxAllowedLength,
+                                    uint8_t * pNameLength );
 
 /**
  * @brief Extract the Shadow message type from a string.
@@ -222,7 +222,7 @@ static ShadowStatus_t extractShadowMessageType( const char * pString,
 static ShadowStatus_t extractThingName( const char * pTopic,
                                         uint16_t topicLength,
                                         uint16_t * pConsumedTopicLength,
-                                        uint16_t * pThingNameLength );
+                                        uint8_t * pThingNameLength );
 
 /**
  * @brief Extract the classic shadow root OR the named shadow root and shadow name from a topic string.
@@ -239,7 +239,7 @@ static ShadowStatus_t extractThingName( const char * pTopic,
 static ShadowStatus_t extractShadowRootAndName( const char * pTopic,
                                                 uint16_t topicLength,
                                                 uint16_t * pConsumedTopicLength,
-                                                uint16_t * pShadowNameLength );
+                                                uint8_t * pShadowNameLength );
 
 /**
  * @brief Get the shadow operation string for a given shadow topic type.
@@ -305,8 +305,8 @@ ShadowStatus_t validateAssembleTopicParameters( ShadowTopicStringType_t topicTyp
                                                 uint8_t thingNameLength,
                                                 const char * pShadowName,
                                                 uint8_t shadowNameLength,
-                                                char * pTopicBuffer,
-                                                uint16_t * pOutLength )
+                                                const char * pTopicBuffer,
+                                                const uint16_t * pOutLength )
 {
     ShadowStatus_t shadowStatus = SHADOW_BAD_PARAMETER;
 
@@ -376,8 +376,8 @@ static ShadowStatus_t containsSubString( const char * pString,
 
 static ShadowStatus_t validateName( const char * pString,
                                     uint16_t stringLength,
-                                    uint16_t maxAllowedLength,
-                                    uint16_t * pNameLength )
+                                    uint8_t maxAllowedLength,
+                                    uint8_t * pNameLength )
 {
     uint16_t index = 0U;
     ShadowStatus_t returnStatus = SHADOW_FAIL;
@@ -428,7 +428,7 @@ static ShadowStatus_t validateName( const char * pString,
 static ShadowStatus_t extractThingName( const char * pTopic,
                                         uint16_t topicLength,
                                         uint16_t * pConsumedTopicLength,
-                                        uint16_t * pThingNameLength )
+                                        uint8_t * pThingNameLength )
 {
     /* Extract thing name. */
     ShadowStatus_t shadowStatus = validateName( &( pTopic[ *pConsumedTopicLength ] ),
@@ -453,7 +453,7 @@ static ShadowStatus_t extractThingName( const char * pTopic,
 static ShadowStatus_t extractShadowRootAndName( const char * pTopic,
                                                 uint16_t topicLength,
                                                 uint16_t * pConsumedTopicLength,
-                                                uint16_t * pShadowNameLength )
+                                                uint8_t * pShadowNameLength )
 {
     /* Look for the named shadow root */
     ShadowStatus_t shadowStatus = containsSubString( &( pTopic[ *pConsumedTopicLength ] ),
@@ -763,14 +763,14 @@ ShadowStatus_t Shadow_MatchTopicString( const char * pTopic,
                                         uint16_t topicLength,
                                         ShadowMessageType_t * pMessageType,
                                         const char ** pThingName,
-                                        uint16_t * pThingNameLength,
+                                        uint8_t * pThingNameLength,
                                         const char ** pShadowName,
-                                        uint16_t * pShadowNameLength )
+                                        uint8_t * pShadowNameLength )
 {
     uint16_t consumedTopicLength = 0U;
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
-    uint16_t thingNameLength = 0;
-    uint16_t shadowNameLength = 0;
+    uint8_t thingNameLength = 0;
+    uint8_t shadowNameLength = 0;
 
     shadowStatus = validateMatchTopicParameters( pTopic, topicLength, pMessageType );
 
@@ -922,3 +922,26 @@ ShadowStatus_t Shadow_AssembleTopicString( ShadowTopicStringType_t topicType,
     return shadowStatus;
 }
 /*-----------------------------------------------------------*/
+
+ShadowStatus_t Shadow_MatchTopic( const char * pTopic,
+                                  uint16_t topicLength,
+                                  ShadowMessageType_t * pMessageType,
+                                  const char ** pThingName,
+                                  uint16_t * pThingNameLength )
+{
+    uint8_t thingNameLength = 0U;
+    ShadowStatus_t shadowStatus = Shadow_MatchTopicString( pTopic,
+                                                           topicLength,
+                                                           pMessageType,
+                                                           pThingName,
+                                                           &thingNameLength,
+                                                           NULL,
+                                                           NULL );
+
+    if( pThingNameLength != NULL )
+    {
+        *pThingNameLength = thingNameLength;
+    }
+
+    return shadowStatus;
+}

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -148,8 +148,8 @@ static ShadowStatus_t validateMatchTopicParameters( const char * pTopic,
  * @param[in]  thingNameLength Length of Thing Name string pointed to by pThingName.
  * @param[in]  pShadowName Shadow Name string.
  * @param[in]  shadowNameLength Length of Shadow Name string pointed to by pShadowName.
- * @param[out] pTopicBuffer Pointer to buffer for returning the topic string.
- * @param[out] pOutLength Pointer to caller-supplied memory for returning the length of the topic string.
+ * @param[in] pTopicBuffer Pointer to buffer for returning the topic string.
+ * @param[in] pOutLength Pointer to caller-supplied memory for returning the length of the topic string.
  *
  * @return Return SHADOW_SUCCESS if the parameters are valid;
  *         return SHADOW_BAD_PARAMETER if not.

--- a/test/unit-test/shadow_utest.c
+++ b/test/unit-test/shadow_utest.c
@@ -967,7 +967,7 @@ void test_Shadow_AssembleTopicString_Invalid_Parameters( void )
 
 /**
  * @brief Tests the behavior of Shadow_MatchTopicString() for classic shadow with valid parameters. Tests Classic
- * shadows through the deprecated legacy API macro Shadow_MatchTopic(), to verify the legacy macros.
+ * shadows through the deprecated legacy API Shadow_MatchTopic().
  */
 void test_Shadow_MatchTopicString_Classic_Happy_Path( void )
 {
@@ -1025,9 +1025,9 @@ void test_Shadow_MatchTopicString_Named_Happy_Path( void )
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
     ShadowMessageType_t messageType = ShadowMessageTypeMaxNum;
     const char * pThingName = NULL;
-    uint16_t thingNameLength = 0U;
+    uint8_t thingNameLength = 0U;
     const char * pShadowName = NULL;
-    uint16_t shadowNameLength = 0U;
+    uint8_t shadowNameLength = 0U;
     const char topicBuffer[ TEST_NAMED_TOPIC_LENGTH_UPDATE_ACCEPTED ] = TEST_NAMED_TOPIC_STRING_UPDATE_ACCEPTED;
     uint16_t bufferSize = TEST_NAMED_TOPIC_LENGTH_UPDATE_ACCEPTED;
 
@@ -1042,6 +1042,20 @@ void test_Shadow_MatchTopicString_Named_Happy_Path( void )
 
     TEST_ASSERT_EQUAL_INT( SHADOW_SUCCESS, shadowStatus );
     TEST_ASSERT_EQUAL_INT( TEST_THING_NAME_LENGTH, thingNameLength );
+    TEST_ASSERT_EQUAL_INT( ShadowMessageTypeUpdateAccepted, messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( TEST_THING_NAME, pThingName, TEST_THING_NAME_LENGTH );
+    TEST_ASSERT_EQUAL_INT( TEST_SHADOW_NAME_LENGTH, shadowNameLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( TEST_SHADOW_NAME, pShadowName, TEST_SHADOW_NAME_LENGTH );
+
+    shadowStatus = Shadow_MatchTopicString( &( topicBuffer[ 0 ] ),
+                                            bufferSize,
+                                            &messageType,
+                                            &pThingName,
+                                            NULL,
+                                            &pShadowName,
+                                            &shadowNameLength );
+
+    TEST_ASSERT_EQUAL_INT( SHADOW_SUCCESS, shadowStatus );
     TEST_ASSERT_EQUAL_INT( ShadowMessageTypeUpdateAccepted, messageType );
     TEST_ASSERT_EQUAL_STRING_LEN( TEST_THING_NAME, pThingName, TEST_THING_NAME_LENGTH );
     TEST_ASSERT_EQUAL_INT( TEST_SHADOW_NAME_LENGTH, shadowNameLength );
@@ -1097,9 +1111,9 @@ void test_Shadow_MatchTopicString_Invalid_Parameters( void )
     ShadowStatus_t shadowStatus = SHADOW_SUCCESS;
     ShadowMessageType_t messageType = ShadowMessageTypeMaxNum;
     const char * pThingName = NULL;
-    uint16_t thingNameLength = 0U;
+    uint8_t thingNameLength = 0U;
     const char * pShadowName = NULL;
-    uint16_t shadowNameLength = 0U;
+    uint8_t shadowNameLength = 0U;
     const char classicTopicBuffer[ TEST_CLASSIC_TOPIC_LENGTH_UPDATE_ACCEPTED ] = TEST_CLASSIC_TOPIC_STRING_UPDATE_ACCEPTED;
     uint16_t classicBufferSize = TEST_CLASSIC_TOPIC_LENGTH_UPDATE_ACCEPTED;
     const char namedTopicBuffer[ TEST_NAMED_TOPIC_LENGTH_UPDATE_ACCEPTED ] = TEST_NAMED_TOPIC_STRING_UPDATE_ACCEPTED;


### PR DESCRIPTION
*Description of changes:*
Convert the type of ThingNameLength and ShadowNameLength to unit8_t from uint16_t. The maximum possible values can very well be in 8 bit limit. Handle backward compatibility with this change to support old API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
