### PR TITLE
Add CBMC proof for Shadow_MatchTopic.

### DIFF
--- a/source/shadow.c
+++ b/source/shadow.c
@@ -148,8 +148,8 @@ static ShadowStatus_t validateMatchTopicParameters( const char * pTopic,
  * @param[in]  thingNameLength Length of Thing Name string pointed to by pThingName.
  * @param[in]  pShadowName Shadow Name string.
  * @param[in]  shadowNameLength Length of Shadow Name string pointed to by pShadowName.
- * @param[in] pTopicBuffer Pointer to buffer for returning the topic string.
- * @param[in] pOutLength Pointer to caller-supplied memory for returning the length of the topic string.
+ * @param[in]  pTopicBuffer Pointer to the topic buffer.
+ * @param[in]  pOutLength Pointer to the length of the topic created.
  *
  * @return Return SHADOW_SUCCESS if the parameters are valid;
  *         return SHADOW_BAD_PARAMETER if not.
@@ -938,6 +938,12 @@ ShadowStatus_t Shadow_MatchTopic( const char * pTopic,
                                                            NULL,
                                                            NULL );
 
+    /* Update the output parameter for Thing name length.
+     * Shadow_MatchTopicString takes a pointer to a 8 bit unsigned integer for
+     * output parameter `Thing name length`, whereas Shadow_MatchTopic takes a
+     * pointer to a 16 bit integer. The maximum possible Thing name length is
+     * 128 bytes and hence unsigned 8 bit integer is large enough to hold the
+     * Thing name length. Refer to #SHADOW_THINGNAME_MAX_LENGTH for more details. */
     if( pThingNameLength != NULL )
     {
         *pThingNameLength = thingNameLength;

--- a/source/shadow.c
+++ b/source/shadow.c
@@ -940,7 +940,7 @@ ShadowStatus_t Shadow_MatchTopic( const char * pTopic,
 
     /* Update the output parameter for Thing name length.
      * Shadow_MatchTopicString takes a pointer to a 8 bit unsigned integer for
-     * output parameter `Thing name length`, whereas Shadow_MatchTopic takes a
+     * output parameter Thing name length, whereas Shadow_MatchTopic takes a
      * pointer to a 16 bit integer. The maximum possible Thing name length is
      * 128 bytes and hence unsigned 8 bit integer is large enough to hold the
      * Thing name length. Refer to #SHADOW_THINGNAME_MAX_LENGTH for more details. */

--- a/test/cbmc/proofs/Shadow_MatchTopic/Makefile
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Makefile
@@ -29,19 +29,16 @@ PROOF_UID = Shadow_MatchTopic
 # AWS (64KB). We allow for a the longest classic shadow topic, but with only
 # reasonable allowance for typical Thing name.
 # $aws/things/thingName/shadow/update/documents
-TOPIC_STRING_LENGTH_MAX=165
-
-# Maximum thing name length.
-# Refer to https://docs.aws.amazon.com/general/latest/gr/iot-core.html#device-shadow-limits
-# for more details about the Device Shadow limits.
-SHADOW_THINGNAME_LENGTH_MAX=128
+TOPIC_STRING_LENGTH_MAX=129
 
 DEFINES += -DTOPIC_STRING_LENGTH_MAX=$(TOPIC_STRING_LENGTH_MAX)
-DEFINES += -DSHADOW_THINGNAME_LENGTH_MAX=$(SHADOW_THINGNAME_LENGTH_MAX)
 INCLUDES +=
 
 # The maximum length of the message type ( /update/documents ) is 17.
 UNWINDSET += strncmp.0:18
+
+# Allow for the longest possible name
+UNWINDSET += __CPROVER_file_local_shadow_c_validateName.0:128
 
 # The number of message types is 8.
 UNWINDSET += __CPROVER_file_local_shadow_c_extractShadowMessageType.0:9

--- a/test/cbmc/proofs/Shadow_MatchTopic/Makefile
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Makefile
@@ -24,21 +24,21 @@ HARNESS_FILE=Shadow_MatchTopic_harness
 PROOF_UID = Shadow_MatchTopic
 
 # The topic length is bounded to reduce the proof run time. This length bounds
-# the time to look for the thing name in the topic string. It adds no value to
-# the proof to input the largest possible topic string accepted by
-# AWS (64KB). We allow for a the longest classic shadow topic, but with only
-# reasonable allowance for typical Thing name.
-# $aws/things/thingName/shadow/update/documents
-TOPIC_STRING_LENGTH_MAX=129
+# the time to look for the thing name in the topic string. The minimum length
+# of the topic string is the length of the SHADOW_PREFIX ("$aws/things/")
+# plus the maximum Shadow Message Type length ("/shadow/update/documents").
+# Memory safety on the buffer holding the topic string can be proven within
+# a reasonable bound. It adds no value to the proof to input the largest possible
+# topic string accepted by AWS (64KB).
+TOPIC_STRING_LENGTH_MAX=50
 
 DEFINES += -DTOPIC_STRING_LENGTH_MAX=$(TOPIC_STRING_LENGTH_MAX)
 INCLUDES +=
 
-# The maximum length of the message type ( /update/documents ) is 17.
-UNWINDSET += strncmp.0:18
+# The maximum length of the message type ( /shadow/update/documents ) is 24.
+UNWINDSET += strncmp.0:25
 
-# Allow for the longest possible name
-UNWINDSET += __CPROVER_file_local_shadow_c_validateName.0:128
+UNWINDSET += __CPROVER_file_local_shadow_c_validateName.0:$(TOPIC_STRING_LENGTH_MAX)
 
 # The number of message types is 8.
 UNWINDSET += __CPROVER_file_local_shadow_c_extractShadowMessageType.0:9

--- a/test/cbmc/proofs/Shadow_MatchTopic/Makefile
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Makefile
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+HARNESS_ENTRY=harness
+HARNESS_FILE=Shadow_MatchTopic_harness
+PROOF_UID = Shadow_MatchTopic
+
+# The topic length is bounded to reduce the proof run time. This length bounds
+# the time to look for the thing name in the topic string. It adds no value to
+# the proof to input the largest possible topic string accepted by
+# AWS (64KB). We allow for a the longest classic shadow topic, but with only
+# reasonable allowance for typical Thing name.
+# $aws/things/thingName/shadow/update/documents
+TOPIC_STRING_LENGTH_MAX=165
+
+DEFINES += -DTOPIC_STRING_LENGTH_MAX=$(TOPIC_STRING_LENGTH_MAX)
+INCLUDES +=
+
+# The maximum length of the message type ( /update/documents ) is 17.
+UNWINDSET += strncmp.0:18
+
+# Allow for the longest possible Thing name
+UNWINDSET += __CPROVER_file_local_shadow_c_validateName.0:128
+
+# The number of message types is 8.
+UNWINDSET += __CPROVER_file_local_shadow_c_extractShadowMessageType.0:9
+
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/shadow_cbmc_state.c
+PROJECT_SOURCES += $(SRCDIR)/source/shadow.c
+
+include ../Makefile.common

--- a/test/cbmc/proofs/Shadow_MatchTopic/Makefile
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Makefile
@@ -26,10 +26,13 @@ PROOF_UID = Shadow_MatchTopic
 # The topic length is bounded to reduce the proof run time. This length bounds
 # the time to look for the thing name in the topic string. The minimum length
 # of the topic string is the length of the SHADOW_PREFIX ("$aws/things/")
-# plus the maximum Shadow Message Type length ("/shadow/update/documents").
-# Memory safety on the buffer holding the topic string can be proven within
-# a reasonable bound. It adds no value to the proof to input the largest possible
-# topic string accepted by AWS (64KB).
+# plus the maximum Shadow Message Type length ("/shadow/update/documents")
+# plus the minimum Thing name length (1 byte). Memory safety on the buffer
+# holding the topic string can be proven within a reasonable bound. It adds
+# no value to the proof to input the largest possible topic string accepted
+# by AWS (64KB). The reasonable bound for topic length is chosen as 50 bytes,
+# which is higher than the minimum (38 bytes) topic length and provides a good
+# allowance for the variable Thing name length (13 bytes).
 TOPIC_STRING_LENGTH_MAX=50
 
 DEFINES += -DTOPIC_STRING_LENGTH_MAX=$(TOPIC_STRING_LENGTH_MAX)

--- a/test/cbmc/proofs/Shadow_MatchTopic/Makefile
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+# Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in

--- a/test/cbmc/proofs/Shadow_MatchTopic/Makefile
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Makefile
@@ -31,18 +31,20 @@ PROOF_UID = Shadow_MatchTopic
 # $aws/things/thingName/shadow/update/documents
 TOPIC_STRING_LENGTH_MAX=165
 
+# Maximum thing name length.
+# Refer to https://docs.aws.amazon.com/general/latest/gr/iot-core.html#device-shadow-limits
+# for more details about the Device Shadow limits.
+SHADOW_THINGNAME_LENGTH_MAX=128
+
 DEFINES += -DTOPIC_STRING_LENGTH_MAX=$(TOPIC_STRING_LENGTH_MAX)
+DEFINES += -DSHADOW_THINGNAME_LENGTH_MAX=$(SHADOW_THINGNAME_LENGTH_MAX)
 INCLUDES +=
 
 # The maximum length of the message type ( /update/documents ) is 17.
 UNWINDSET += strncmp.0:18
 
-# Allow for the longest possible Thing name
-UNWINDSET += __CPROVER_file_local_shadow_c_validateName.0:128
-
 # The number of message types is 8.
 UNWINDSET += __CPROVER_file_local_shadow_c_extractShadowMessageType.0:9
-
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROOF_SOURCES += $(SRCDIR)/test/cbmc/sources/shadow_cbmc_state.c

--- a/test/cbmc/proofs/Shadow_MatchTopic/README.md
+++ b/test/cbmc/proofs/Shadow_MatchTopic/README.md
@@ -1,0 +1,10 @@
+Shadow_MatchTopic proof
+==============
+
+This directory contains a memory safety proof for Shadow_MatchTopic.
+
+To run the proof.
+* Add cbmc, goto-cc, goto-instrument, goto-analyzer, and cbmc-viewer
+  to your path.
+* Run "make".
+* Open html/index.html in a web browser.

--- a/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
@@ -44,7 +44,6 @@ void harness()
     pThingName = mallocCanFail( sizeof( *pThingName ) );
     pThingNameLength = mallocCanFail( sizeof( *pThingNameLength ) );
 
-
     Shadow_MatchTopic( pTopicName,
                        topicNameLength,
                        pMessageType,

--- a/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
@@ -37,8 +37,6 @@ void harness()
     uint16_t * pThingNameLength;
 
     __CPROVER_assume( topicNameLength < TOPIC_STRING_LENGTH_MAX );
-    __CPROVER_assume( *pThingNameLength < SHADOW_THINGNAME_LENGTH_MAX );
-
     pTopicName = mallocCanFail( topicNameLength );
 
     pMessageType = mallocCanFail( sizeof( *pMessageType ) );

--- a/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
@@ -1,0 +1,53 @@
+/*
+ * AWS IoT Device Shadow v1.0.2
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file Shadow_MatchTopic_harness.c
+ * @brief Implements the proof harness for Shadow_MatchTopic function.
+ */
+
+#include "shadow.h"
+#include "shadow_cbmc_state.h"
+
+void harness()
+{
+    const char * pTopicName;
+    uint16_t topicNameLength;
+    ShadowMessageType_t * pMessageType;
+    const char ** pThingName;
+    uint16_t * pThingNameLength;
+
+    __CPROVER_assume( topicNameLength < TOPIC_STRING_LENGTH_MAX );
+    pTopicName = mallocCanFail( topicNameLength );
+
+    pMessageType = mallocCanFail( sizeof( *pMessageType ) );
+
+    pThingName = mallocCanFail( sizeof( *pThingName ) );
+    pThingNameLength = mallocCanFail( sizeof( *pThingNameLength ) );
+
+
+    Shadow_MatchTopic( pTopicName,
+                       topicNameLength,
+                       pMessageType,
+                       pThingName,
+                       pThingNameLength );
+}

--- a/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
@@ -37,6 +37,8 @@ void harness()
     uint16_t * pThingNameLength;
 
     __CPROVER_assume( topicNameLength < TOPIC_STRING_LENGTH_MAX );
+    __CPROVER_assume( *pThingNameLength < SHADOW_THINGNAME_LENGTH_MAX );
+
     pTopicName = mallocCanFail( topicNameLength );
 
     pMessageType = mallocCanFail( sizeof( *pMessageType ) );

--- a/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
+++ b/test/cbmc/proofs/Shadow_MatchTopic/Shadow_MatchTopic_harness.c
@@ -1,6 +1,6 @@
 /*
  * AWS IoT Device Shadow v1.0.2
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/test/cbmc/proofs/Shadow_MatchTopic/cbmc-proof.txt
+++ b/test/cbmc/proofs/Shadow_MatchTopic/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/test/cbmc/proofs/Shadow_MatchTopic/cbmc-viewer.json
+++ b/test/cbmc/proofs/Shadow_MatchTopic/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+
+  ],
+  "proof-name": "Shadow_MatchTopic",
+  "proof-root": "../cbmc/proofs"
+}


### PR DESCRIPTION
*Description of changes:*
Add CBMC proof for Shadow_MatchTopic API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
